### PR TITLE
chore: uuid を v11 に更新（脆弱性解消）

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@react-navigation/native-stack": "^6.9.17",
     "@tanstack/react-query": "^5",
     "@types/react-native-vector-icons": "^6.4.18",
-    "@types/uuid": "^9.0.8",
     "axios": "^1",
     "babel-plugin-module-resolver": "^5.0.2",
     "dayjs": "^1",
@@ -66,7 +65,7 @@
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.10.0",
     "recoil": "^0.7.7",
-    "uuid": "^9.0.1"
+    "uuid": "^11"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2605,11 +2605,6 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
-"@types/uuid@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
-  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
-
 "@types/ws@^8.0.0":
   version "8.18.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
@@ -8365,15 +8360,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^11:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 validate-npm-package-name@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
## 概要
本番/実行時に関わる依存の脆弱性を解消。

- 直接依存の **uuid を 9 → 11.1.1** に更新（GHSA: v3/v5/v6 で `buf` 引数使用時のバッファ境界チェック漏れ。patched `>=11.1.1`）
- uuid v11 は型内蔵のため不要な `@types/uuid` を削除
- `uuid` はアプリソースで直接 import されておらず（GraphQLの `uuid` スカラー型とは別物）、更新の破壊リスクなし

## 状況
- `yarn audit`（production 依存）: **実行時に関わる脆弱性 0 件**
- 残る `xcode#uuid@7.0.3`（4件・moderate）は **Expo CLI (config-plugins) のビルド時専用依存**でアプリに同梱されず、実行時リスクなし。強制 resolution は `expo prebuild` を壊すリスクがあるため据え置き（Expo 側の更新待ち）
- tsc アプリ本体 0 エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)