### PR TITLE
fix: 認証初期化のハング対策（タイムアウトのセーフティネット）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,9 @@ export const App: FC = () => {
       }) ?? TestIds.BANNER;
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
+    let settled = false;
+
+    const applyUser = (user: typeof auth.currentUser) => {
       if (user) {
         user.getIdToken().then((idToken: string) => setIdToken(idToken));
         // MEMO: user は Object.freeze() されているため、setUser で更新するときは新しいオブジェクトを渡す必要がある。
@@ -63,9 +65,34 @@ export const App: FC = () => {
         setUser(null);
         setIdToken(null);
       }
+    };
+
+    // onAuthStateChanged の発火 or タイムアウトのどちらか一度だけ初期化を完了させる。
+    const settle = (user: typeof auth.currentUser) => {
+      if (settled) return;
+      settled = true;
+      applyUser(user);
       setInitializing(false);
-    });
-    return () => unsubscribe();
+    };
+
+    const unsubscribe = onAuthStateChanged(auth, (user) => settle(user));
+
+    // 安全策: firebase 初期化(トークン更新等のネットワーク要求)がハングしても
+    // 無限ローディングにならないよう、一定時間で auth.currentUser を使って先へ進める。
+    // currentUser があればログイン状態を維持でき、不要な再ログインを避けられる。
+    const fallbackTimer = setTimeout(() => {
+      if (!settled) {
+        console.warn(
+          `[auth] onAuthStateChanged が8秒以内に未発火。currentUser で継続 (currentUser: ${!!auth.currentUser})`,
+        );
+        settle(auth.currentUser);
+      }
+    }, 8000);
+
+    return () => {
+      clearTimeout(fallbackTimer);
+      unsubscribe();
+    };
   }, [setIdToken, setUser]);
 
   if (initializing) return <LoadingScreen />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,25 +67,30 @@ export const App: FC = () => {
       }
     };
 
-    // onAuthStateChanged の発火 or タイムアウトのどちらか一度だけ初期化を完了させる。
-    const settle = (user: typeof auth.currentUser) => {
+    // 初期化(LoadingScreen 解除)は一度だけ。ユーザー状態の反映は毎回行う。
+    const finishInit = () => {
       if (settled) return;
       settled = true;
-      applyUser(user);
       setInitializing(false);
     };
 
-    const unsubscribe = onAuthStateChanged(auth, (user) => settle(user));
+    // ログイン/ログアウトのたびに毎回ユーザー状態を反映し、初回のみ初期化を完了。
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      applyUser(user);
+      finishInit();
+    });
 
     // 安全策: firebase 初期化(トークン更新等のネットワーク要求)がハングしても
-    // 無限ローディングにならないよう、一定時間で auth.currentUser を使って先へ進める。
+    // 無限ローディングにならないよう、一定時間で auth.currentUser を使って初期化を完了。
     // currentUser があればログイン状態を維持でき、不要な再ログインを避けられる。
+    // 以降 onAuthStateChanged が発火すれば applyUser で状態は更新される。
     const fallbackTimer = setTimeout(() => {
       if (!settled) {
         console.warn(
           `[auth] onAuthStateChanged が8秒以内に未発火。currentUser で継続 (currentUser: ${!!auth.currentUser})`,
         );
-        settle(auth.currentUser);
+        applyUser(auth.currentUser);
+        finishInit();
       }
     }, 8000);
 


### PR DESCRIPTION
## 概要
永続ログインセッションの復元時に、firebase の `onAuthStateChanged` が初期化（トークン更新のネットワーク要求）でハングし、`LoadingScreen` が無限に続く事象への対策。

## 変更
- `App.tsx` の認証初期化 `useEffect` に **8秒のタイムアウト**を追加
- 時間内に `onAuthStateChanged` が発火しない場合、`auth.currentUser` を使って初期化を完了 → 無限ローディングを防止
- `currentUser` があればログイン状態を維持（不要な再ログインを回避）
- フォールバック発火時に Metro ログへ警告出力（原因切り分け用）

## 状況・要検証
- 本事象は「ログイン済み＋IDトークン期限切れ＋コールドスタート」で再現するが、開発環境では認証情報がなく**再現・検証ができていない**
- tsc アプリ本体 0 エラー / バンドル成功は確認済み

### 検証手順（お願い）
1. アプリでログイン
2. アプリを完全終了し、しばらく（トークン期限=約1時間）置くか、期限切れ状態で再起動
3. 以前は LoadingScreen で固まっていたのが、**8秒以内に画面が進む**ことを確認
4. Metro ログに `[auth] onAuthStateChanged が8秒以内に未発火...` が出るか（出れば初期化ハングが原因と確定）

ログの内容次第で、必要ならより根本的な firebase 設定の見直しに進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)