### PR TITLE
chore: react-native-google-mobile-ads を v16 に更新

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,10 +45,13 @@
           "backgroundColor": "#ffffff"
         }
       ],
-      "expo-font"
+      "expo-font",
+      [
+        "react-native-google-mobile-ads",
+        {
+          "iosAppId": "ca-app-pub-1013230797140961~9512399959"
+        }
+      ]
     ]
-  },
-  "react-native-google-mobile-ads": {
-    "ios_app_id": "ca-app-pub-1013230797140961~9512399959"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-native-element-dropdown": "^2.10.1",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-get-random-values": "~1.11.0",
-    "react-native-google-mobile-ads": "^13.6.0",
+    "react-native-google-mobile-ads": "^16",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-modal-datetime-picker": "^17.1.0",
     "react-native-reanimated": "4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,7 +2061,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@iabtcf/core@^1.5.3":
+"@iabtcf/core@^1.5.6":
   version "1.5.6"
   resolved "https://registry.yarnpkg.com/@iabtcf/core/-/core-1.5.6.tgz#92568d89252fbf205aa65836703cb0a52e812382"
   integrity sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w==
@@ -7132,12 +7132,12 @@ react-native-get-random-values@~1.11.0:
   dependencies:
     fast-base64-decode "^1.0.0"
 
-react-native-google-mobile-ads@^13.6.0:
-  version "13.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-google-mobile-ads/-/react-native-google-mobile-ads-13.6.1.tgz#9f807da2293a32cb80418154142cd34d163abd7a"
-  integrity sha512-+VXeT79H/fipOQcic2oDGqr3k8fDkg+DMm9kuxyrnppqXJ9G45HvvpTHDGDDGMHHx8kVLAbpa0WZ/i/evnxrjQ==
+react-native-google-mobile-ads@^16:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-google-mobile-ads/-/react-native-google-mobile-ads-16.4.0.tgz#67501de357830fcd8ae39fa7b71730ce3a70e684"
+  integrity sha512-I+H9huEO30XaNZ4InPLCZS2DsnbegGjWqFavJMFssDnm78OPJkAOodY6OSCsEtonq0pdG2YbhchhIuZmE427Mw==
   dependencies:
-    "@iabtcf/core" "^1.5.3"
+    "@iabtcf/core" "^1.5.6"
     use-deep-compare-effect "^1.8.1"
 
 react-native-is-edge-to-edge@^1.3.1:


### PR DESCRIPTION
## 概要
react-native-google-mobile-ads を v13 → v16 に更新し、AdMob 設定を Expo config プラグイン方式へ移行。

## 変更
- `react-native-google-mobile-ads` 13.6.1 → **16.4.0**
- AdMob 設定を `app.json` ルートの `react-native-google-mobile-ads` キーから、**v16 の config プラグイン**（`plugins` に `iosAppId` 指定）へ移行
  - 旧方式は `ios_config.sh` がビルド時に読む仕組みで doctor 警告が出ていた。プラグイン方式は Expo 推奨で警告も解消
- 使用 API は `BannerAd` / `BannerAdSize` / `TestIds` のみで v16 と互換（コード変更なし）

## 動作確認
- tsc アプリ本体 0 エラー / expo-doctor 20/20
- ネイティブ再ビルド（`ios/` 再生成 + pod install で v16 SDK 導入）
- シミュレータで**広告バナー（テスト広告）の表示を確認** → GADApplicationIdentifier がプラグイン経由で正しく設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)