### PR TITLE
chore: ルートtsconfigから functions/ を除外

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "babel.config.js",
     "metro.config.js",
     "jest.config.js",
-    "src/interface/__generated__/"
+    "src/interface/__generated__/",
+    "functions"
   ]
 }


### PR DESCRIPTION
## 概要
アプリ本体の型チェックが、別プロジェクトである `functions/`（Firebase Cloud Functions）まで拾ってしまい、依存未インストールにより 3 件の tsc エラーが出ていた問題を修正。

## 変更
- ルート `tsconfig.json` の `exclude` に `functions` を追加
- `functions/` は独自の `tsconfig.json` を持つ独立プロジェクトのため、アプリのルート型チェック対象から外すのが正しい
- これでアプリ本体の `tsc --noEmit` が **0 エラー**に

## 補足（別タスク）
`functions/` 自体の依存（firebase-admin 11 / firebase-functions 4 / TS 4）は古いが、更新には以下の破壊的変更対応とデプロイ検証が必要なため本PRには含めない:
- `functions.config()` は firebase-functions v6 で撤廃 → `.env`/`defineSecret` へ移行
- Gen1 トリガー（`functions.auth.user().onCreate()`）の import 経路変更 or Gen2 移行
- サインアップ→Hasura クレーム設定の重要処理のため、Firebase エミュレータ/デプロイでの検証必須

🤖 Generated with [Claude Code](https://claude.com/claude-code)