### PR TITLE
chore: eas.json submit に実 ID を設定 (Team ID / ascAppId)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -27,9 +27,8 @@
   "submit": {
     "production": {
       "ios": {
-        "appleId": "REPLACE_WITH_APPLE_ID_EMAIL",
-        "ascAppId": "REPLACE_WITH_APP_STORE_CONNECT_APP_ID",
-        "appleTeamId": "REPLACE_WITH_APPLE_TEAM_ID"
+        "appleTeamId": "8QUC4U6CVZ",
+        "ascAppId": "6504145333"
       }
     }
   }


### PR DESCRIPTION
## 目的
`eas submit` のプレースホルダ (`REPLACE_WITH_...`) が不正値エラーになっていたため実値へ置換し、以降の提出を非対話化する。

## 変更
- `submit.production.ios.appleTeamId`: `8QUC4U6CVZ`
- `submit.production.ios.ascAppId`: `6504145333`
- `appleId` は App Store Connect API キー認証を使うため不要（キーは EAS が保管）

## 状況
build 6 (v1.0.2) は App Store Connect へアップロード成功済み。あとは ASC 側でバージョン紐付け→審査提出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)